### PR TITLE
Properly configured Redis for our environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ before_install:
   - echo $DB_HOST > ./kite-api/.env
   - echo $DB_AUTH_USER > ./kite-api/.env
   - echo $DB_AUTH_PASS > ./kite-api/.env
+  - echo $DB_CONTAINER_USER > ./kite-api/.env
+  - echo $DB_CONTAINER_PASS > ./kite-api/.env
 addons:
   apt:
     sources:

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -23,8 +23,8 @@ services:
             - kitenginx
   kite-redis:
     build: ./kite-redis
-    ports:
-      - "6379:6379"
+    sysctls:
+      net.core.somaxconn: 1024
     networks:
       kite:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
             - kitenginx
   kite-redis:
     build: ./kite-redis
-    ports:
-      - "6379:6379"
+    sysctls:
+      net.core.somaxconn: 1024
     networks:
       kite:
         aliases:

--- a/kite-redis/Dockerfile
+++ b/kite-redis/Dockerfile
@@ -1,1 +1,6 @@
 FROM redis:5.0.3-alpine
+
+COPY ./kite-redis.conf /etc/kite-redis.conf
+
+EXPOSE 6379
+CMD ["redis-server", "/etc/kite-redis.conf"]

--- a/kite-redis/Dockerfile
+++ b/kite-redis/Dockerfile
@@ -2,5 +2,4 @@ FROM redis:5.0.3-alpine
 
 COPY ./kite-redis.conf /etc/kite-redis.conf
 
-EXPOSE 6379
 CMD ["redis-server", "/etc/kite-redis.conf"]

--- a/kite-redis/kite-redis.conf
+++ b/kite-redis/kite-redis.conf
@@ -1,0 +1,2 @@
+tcp-backlog 1024
+save 60 5000


### PR DESCRIPTION
- Closes ports on Redis containers
- Bumps max connections up to 1024
- Lowers the 60 second save default from 10000 edits to 5000
- Adds support for the DB container user on Travis CI

I have also figured out how to disable Transparent Huge Pages, but it is a host specific setting, not a container specific setting. For development we can just disregard the warning. On production we have to manually disable this. 
